### PR TITLE
Compute Application Server User roles from Organization Service

### DIFF
--- a/saml/gatein-saml-plugin/pom.xml
+++ b/saml/gatein-saml-plugin/pom.xml
@@ -67,6 +67,10 @@
          <artifactId>sso-agent</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.exoplatform.core</groupId>
+         <artifactId>exo.core.component.organization.api</artifactId>
+      </dependency>
+      <dependency>
         <groupId>org.picketlink</groupId>
         <artifactId>picketlink-federation</artifactId>
       </dependency>


### PR DESCRIPTION
Task-24424 : 403 Error when rendering  the spaces Management permissions tab

When the saml is configured, if the IDP does not provide the administrators role in the assertion, all rest services with @RolesAllowed("administrators") return a 403 error.
In fact, the IDP shouldn't know if a user is administrator on eXo or not. The administrator role should be computed by eXo.
This fix allows to computed user roles from OrganizationService when the SAML process success at the beginning of the session. Roles are added in the principal which is used in all the session