### PR TITLE
Add option to force saml username in lower cases

### DIFF
--- a/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/AbstractSPFormAuthenticator.java
+++ b/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/AbstractSPFormAuthenticator.java
@@ -762,6 +762,13 @@ public abstract class AbstractSPFormAuthenticator extends BaseFormAuthenticator 
     protected abstract String getContextPath();
 
     protected Principal getGenericPrincipal(Request request, String username, List<String> roles){
+        //sometimes, IDP send username in assertion with capitals letters, or with inconsistent format.
+        //this option allows to force the username in lower case, just before creating the principal,
+        //so that, all operations in exo side will use a consistant format.
+        String forceLowerCase = System.getProperty("gatein.sso.saml.username.forcelowercase","false");
+        if(forceLowerCase.equalsIgnoreCase("true")) {
+            username=username.toLowerCase();
+        }
         return new GenericPrincipal(username, null, roles);
     }
 


### PR DESCRIPTION
In some cases, the username which come from IDP contains capital letters. It could also be non consistent (some usernames with capital letter some other not).
This fix add an option to allow to force the username in lower case. If the option is not defined or different to true, the username is not changed.