### PR TITLE
MAINT-28303 : [SAML] Impossible to import users csv

### DIFF
--- a/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
+++ b/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
@@ -112,7 +112,7 @@ public class SAML2LogoutFilter extends SPFilter implements SSOInterceptor {
   }
 
   public static boolean isPortalLogoutInProgress(HttpServletRequest request) {
-    if (StringUtils.equals(request.getParameter("portal:action"), "Logout") && request.getRemoteUser() != null) {
+    if (request.getQueryString().contains("portal:action=Logout") && request.getRemoteUser() != null) {
       return true;
     }
     return false;

--- a/saml/gatein-saml-plugin/src/test/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilterTest.java
+++ b/saml/gatein-saml-plugin/src/test/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilterTest.java
@@ -76,7 +76,7 @@ public class SAML2LogoutFilterTest extends TestCase {
     when(request.getRequestURI()).thenReturn("/portal");
     when(httpSession.getAttribute(SAML2LogoutFilter.SAML_LOGOUT_ATTRIBUTE)).thenReturn("/portal?portal:action=Logout");
     when(request.getRemoteUser()).thenReturn("root");
-    when(request.getQueryString()).thenReturn("/portal?portal:action=Logout");
+    when(request.getQueryString()).thenReturn("");
     when(request.getSession()).thenReturn(httpSession);
     when(filterConfig.getServletContext()).thenReturn(servletContext);
     when(servletContext.getServletContextName()).thenReturn("portal");
@@ -95,7 +95,7 @@ public class SAML2LogoutFilterTest extends TestCase {
     saml2LogoutFilter.init(filterConfig);
     saml2LogoutFilter.doFilter(request, response, chain);
 
-    verify(response, VerificationModeFactory.times(0)).sendRedirect(eq("/portal?portal:action=Logout"));
+    verify(response, VerificationModeFactory.times(1)).sendRedirect(eq("/portal?portal:action=Logout"));
   }
 
   public void testLogoutProcessStep3AndStep4() throws Exception {

--- a/saml/gatein-saml-plugin/src/test/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilterTest.java
+++ b/saml/gatein-saml-plugin/src/test/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilterTest.java
@@ -76,6 +76,7 @@ public class SAML2LogoutFilterTest extends TestCase {
     when(request.getRequestURI()).thenReturn("/portal");
     when(httpSession.getAttribute(SAML2LogoutFilter.SAML_LOGOUT_ATTRIBUTE)).thenReturn("/portal?portal:action=Logout");
     when(request.getRemoteUser()).thenReturn("root");
+    when(request.getQueryString()).thenReturn("/portal?portal:action=Logout");
     when(request.getSession()).thenReturn(httpSession);
     when(filterConfig.getServletContext()).thenReturn(servletContext);
     when(servletContext.getServletContextName()).thenReturn("portal");
@@ -94,7 +95,7 @@ public class SAML2LogoutFilterTest extends TestCase {
     saml2LogoutFilter.init(filterConfig);
     saml2LogoutFilter.doFilter(request, response, chain);
 
-    verify(response, VerificationModeFactory.times(1)).sendRedirect(eq("/portal?portal:action=Logout"));
+    verify(response, VerificationModeFactory.times(0)).sendRedirect(eq("/portal?portal:action=Logout"));
   }
 
   public void testLogoutProcessStep3AndStep4() throws Exception {


### PR DESCRIPTION
This problem is caused by the **isPortalLogoutInProgress** during the filter chain that calls the **request.getParameter()** function, which triggers an implicit parsing of all request parameters, for this @FormParam always will be null.
**SOLUTION** : check portal log out with request.getQueryString()