### PR TITLE
Task-36267 : when saml is configured, and when you save a wiki page c…

### DIFF
--- a/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/AbstractSPFormAuthenticator.java
+++ b/saml/gatein-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/AbstractSPFormAuthenticator.java
@@ -382,6 +382,14 @@ public abstract class AbstractSPFormAuthenticator extends BaseFormAuthenticator 
      * @return true if this is a local SAML logout
      */
     private boolean isLocalLogout(Request request) {
+        try {
+            if (request.getCharacterEncoding()==null) {
+                request.setCharacterEncoding("UTF-8");
+            }
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Request have no encoding, and we are unable to set it to UTF-8");
+            logger.error(e);
+        }
         String lloStr = request.getParameter(GeneralConstants.LOCAL_LOGOUT);
         return isNotNull(lloStr) && "true".equalsIgnoreCase(lloStr);
     }


### PR DESCRIPTION
…… (#13)

* Task-36267 : when saml is configured, and when you save a wiki page containing accentued char, there is an encoding problem

Before this fix, the SSODelegateValve checks if we are in logout process, and for that check a parameter in url. But at this point, the characterEncoding for this request is not set. It is set later.
This fix add the character encoding if not present.

* Add logger in catch