### PR TITLE
TASK-26265 Avoid appending ArtifactId in version

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -16,6 +16,7 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
+          <appendAssemblyId>false</appendAssemblyId>
           <descriptors>
             <descriptor>src/main/assembly/src.xml</descriptor>
           </descriptors>


### PR DESCRIPTION
Prior to this change, after having changed the used maven assembly plugin version (inherited from new parent), the deployed artifact version of `sso-packaging` was changing deployed version to append artifactId.
This fixes the deployed artifact version.