### PR TITLE
fix: allow to redirect on initialUri when using SAML - EXO-66292 - meeds-io/meeds#1104

### DIFF
--- a/agent/src/main/java/org/gatein/sso/agent/filter/LoginRedirectFilter.java
+++ b/agent/src/main/java/org/gatein/sso/agent/filter/LoginRedirectFilter.java
@@ -70,7 +70,11 @@ public class LoginRedirectFilter extends AbstractSSOInterceptor
     */
    protected String getLoginRedirectURL(HttpServletRequest httpRequest)
    {
-      return this.loginUrl;
+		 String url = this.loginUrl;
+		 if (httpRequest.getQueryString() != null) {
+			 url = url + "?" + httpRequest.getQueryString();
+		 }
+		 return url;
    }
 
 }


### PR DESCRIPTION
Before this fix, with SAML, user is not redirected on initialUri if he is not connected to IDP after successul authentication This modification ensure to add the initialURI parameter in the next request after the /sso request

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
