### PR TITLE
feat: Cleanup Dependencies to rely on Spring Dependencies Tree - Meeds-io/MIPs#57

### DIFF
--- a/sso-agent/pom.xml
+++ b/sso-agent/pom.xml
@@ -42,8 +42,8 @@
       <scope>provided</scope>
     </dependency>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/sso-saml-plugin/pom.xml
+++ b/sso-saml-plugin/pom.xml
@@ -202,7 +202,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
       <scope>provided</scope>
     </dependency>
@@ -286,8 +286,8 @@
       <artifactId>exo.core.component.organization.api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -405,8 +405,7 @@
             <configuration>
               <patchFile>
                 ${basedir}/src/main/patches/java.security.acl.Group.patch</patchFile>
-              <patchTrackingFile>
-                ${project.build.directory}/java.security.acl.Group-patches-applied.txt</patchTrackingFile>
+              <patchTrackingFile>${project.build.directory}/java.security.acl.Group-patches-applied.txt</patchTrackingFile>
               <failurePhrases>skip</failurePhrases>
             </configuration>
             <phase>process-resources</phase>
@@ -418,8 +417,18 @@
             <id>javax.servlet-patch</id>
             <configuration>
               <patchFile>${basedir}/src/main/patches/javax.servlet.patch</patchFile>
-              <patchTrackingFile>
-                ${project.build.directory}/javax.servlet-patches-applied.txt</patchTrackingFile>
+              <patchTrackingFile>${project.build.directory}/javax.servlet-patches-applied.txt</patchTrackingFile>
+            </configuration>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>apply</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>javax.persistence-patch</id>
+            <configuration>
+              <patchFile>${basedir}/src/main/patches/javax.persistence.patch</patchFile>
+              <patchTrackingFile>${project.build.directory}/javax.persistence-patches-applied.txt</patchTrackingFile>
             </configuration>
             <phase>process-resources</phase>
             <goals>

--- a/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
+++ b/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
@@ -2,7 +2,7 @@ package org.gatein.sso.saml.plugin.filter;
 
 import java.io.IOException;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.gatein.sso.agent.filter.api.SSOInterceptor;
 import org.gatein.sso.agent.filter.api.SSOInterceptorInitializationContext;
 import org.picketlink.common.constants.GeneralConstants;

--- a/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/BaseFormAuthenticator.java
+++ b/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/BaseFormAuthenticator.java
@@ -35,7 +35,7 @@ import org.apache.catalina.authenticator.FormAuthenticator;
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.tomcat.util.descriptor.web.LoginConfig;
 import org.gatein.sso.saml.plugin.filter.SAMLSPServletContextWrapper;
 import org.picketlink.common.ErrorCodes;

--- a/sso-saml-plugin/src/main/patches/javax.persistence.patch
+++ b/sso-saml-plugin/src/main/patches/javax.persistence.patch
@@ -1,0 +1,175 @@
+diff -uNr picketlink-orig/org/jboss/security/acl/ACLEntryImpl.java picketlink/org/jboss/security/acl/ACLEntryImpl.java
+--- picketlink-orig/org/jboss/security/acl/ACLEntryImpl.java	2013-10-08 17:01:34.000000000 +0100
++++ picketlink/org/jboss/security/acl/ACLEntryImpl.java	2023-12-21 09:00:31.807478000 +0100
+@@ -23,14 +23,14 @@
+ 
+ import java.io.Serializable;
+ 
+-import javax.persistence.Entity;
+-import javax.persistence.GeneratedValue;
+-import javax.persistence.Id;
+-import javax.persistence.ManyToOne;
+-import javax.persistence.PostLoad;
+-import javax.persistence.PrePersist;
+-import javax.persistence.Table;
+-import javax.persistence.Transient;
++import jakarta.persistence.Entity;
++import jakarta.persistence.GeneratedValue;
++import jakarta.persistence.Id;
++import jakarta.persistence.ManyToOne;
++import jakarta.persistence.PostLoad;
++import jakarta.persistence.PrePersist;
++import jakarta.persistence.Table;
++import jakarta.persistence.Transient;
+ 
+ import org.jboss.security.PicketBoxMessages;
+ import org.jboss.security.identity.Identity;
+diff -uNr picketlink-orig/org/jboss/security/acl/ACLImpl.java picketlink/org/jboss/security/acl/ACLImpl.java
+--- picketlink-orig/org/jboss/security/acl/ACLImpl.java	2013-10-08 17:01:34.000000000 +0100
++++ picketlink/org/jboss/security/acl/ACLImpl.java	2023-12-21 09:00:31.811478000 +0100
+@@ -28,15 +28,15 @@
+ import java.util.HashMap;
+ import java.util.Map;
+ 
+-import javax.persistence.CascadeType;
+-import javax.persistence.Column;
+-import javax.persistence.Entity;
+-import javax.persistence.FetchType;
+-import javax.persistence.GeneratedValue;
+-import javax.persistence.Id;
+-import javax.persistence.OneToMany;
+-import javax.persistence.Table;
+-import javax.persistence.Transient;
++import jakarta.persistence.CascadeType;
++import jakarta.persistence.Column;
++import jakarta.persistence.Entity;
++import jakarta.persistence.FetchType;
++import jakarta.persistence.GeneratedValue;
++import jakarta.persistence.Id;
++import jakarta.persistence.OneToMany;
++import jakarta.persistence.Table;
++import jakarta.persistence.Transient;
+ 
+ import org.hibernate.annotations.Cascade;
+ import org.jboss.security.PicketBoxMessages;
+diff -uNr picketlink-orig/org/jboss/security/acl/JPAPersistenceStrategy.java picketlink/org/jboss/security/acl/JPAPersistenceStrategy.java
+--- picketlink-orig/org/jboss/security/acl/JPAPersistenceStrategy.java	2013-10-08 17:01:34.000000000 +0100
++++ picketlink/org/jboss/security/acl/JPAPersistenceStrategy.java	2023-12-21 09:00:31.819478000 +0100
+@@ -5,11 +5,11 @@
+ import java.util.HashMap;
+ import java.util.Map;
+ 
+-import javax.persistence.EntityManager;
+-import javax.persistence.EntityManagerFactory;
+-import javax.persistence.EntityTransaction;
+-import javax.persistence.NoResultException;
+-import javax.persistence.Persistence;
++import jakarta.persistence.EntityManager;
++import jakarta.persistence.EntityManagerFactory;
++import jakarta.persistence.EntityTransaction;
++import jakarta.persistence.NoResultException;
++import jakarta.persistence.Persistence;
+ 
+ import org.jboss.security.PicketBoxMessages;
+ import org.jboss.security.authorization.Resource;
+diff -uNr picketlink-orig/org/jboss/security/acl/Util.java picketlink/org/jboss/security/acl/Util.java
+--- picketlink-orig/org/jboss/security/acl/Util.java	2013-10-08 17:01:34.000000000 +0100
++++ picketlink/org/jboss/security/acl/Util.java	2023-12-21 09:00:31.819478000 +0100
+@@ -112,7 +112,7 @@
+    /**
+     * <p>
+     * Obtains an {@code Object} that can represent the specified resource uniquely. It first tries to find
+-    * a {@code Field} annotated with a {@code javax.persistence.Id} annotation. If such field is found, the
++    * a {@code Field} annotated with a {@code jakarta.persistence.Id} annotation. If such field is found, the
+     * method tries to read the field's value. If no annotated field is found, this method just tries to
+     * invoke a {@code getId()} method on the resource.
+     * </p>
+@@ -125,10 +125,10 @@
+    {
+       Class<? extends Resource> resourceClass = resource.getClass();
+       Object resourceKey = null;
+-      // first search for a field with a javax.persistence.Id annotation.
++      // first search for a field with a jakarta.persistence.Id annotation.
+       for (Field field : resourceClass.getDeclaredFields())
+       {
+-         if (field.getAnnotation(javax.persistence.Id.class) != null)
++         if (field.getAnnotation(jakarta.persistence.Id.class) != null)
+          {
+             // found a field - try to get its value reflectively.
+             try
+diff -uNr picketlink-orig/org/picketlink/identity/federation/core/sts/registry/AbstractJPARegistry.java picketlink/org/picketlink/identity/federation/core/sts/registry/AbstractJPARegistry.java
+--- picketlink-orig/org/picketlink/identity/federation/core/sts/registry/AbstractJPARegistry.java	2015-02-23 17:06:38.000000000 +0100
++++ picketlink/org/picketlink/identity/federation/core/sts/registry/AbstractJPARegistry.java	2023-12-21 09:00:31.819478000 +0100
+@@ -21,8 +21,8 @@
+ import org.picketlink.common.PicketLinkLogger;
+ import org.picketlink.common.PicketLinkLoggerFactory;
+ 
+-import javax.persistence.EntityManagerFactory;
+-import javax.persistence.Persistence;
++import jakarta.persistence.EntityManagerFactory;
++import jakarta.persistence.Persistence;
+ 
+ /**
+  * @author <a href="mailto:psilva@redhat.com">Pedro Silva</a>
+diff -uNr picketlink-orig/org/picketlink/identity/federation/core/sts/registry/JPABasedRevocationRegistry.java picketlink/org/picketlink/identity/federation/core/sts/registry/JPABasedRevocationRegistry.java
+--- picketlink-orig/org/picketlink/identity/federation/core/sts/registry/JPABasedRevocationRegistry.java	2015-02-23 17:06:38.000000000 +0100
++++ picketlink/org/picketlink/identity/federation/core/sts/registry/JPABasedRevocationRegistry.java	2023-12-21 09:00:31.823478000 +0100
+@@ -17,8 +17,8 @@
+  */
+ package org.picketlink.identity.federation.core.sts.registry;
+ 
+-import javax.persistence.EntityManager;
+-import javax.persistence.EntityTransaction;
++import jakarta.persistence.EntityManager;
++import jakarta.persistence.EntityTransaction;
+ 
+ /**
+  * <p>
+diff -uNr picketlink-orig/org/picketlink/identity/federation/core/sts/registry/JPABasedTokenRegistry.java picketlink/org/picketlink/identity/federation/core/sts/registry/JPABasedTokenRegistry.java
+--- picketlink-orig/org/picketlink/identity/federation/core/sts/registry/JPABasedTokenRegistry.java	2015-08-21 10:05:52.000000000 +0100
++++ picketlink/org/picketlink/identity/federation/core/sts/registry/JPABasedTokenRegistry.java	2023-12-21 09:00:31.823478000 +0100
+@@ -18,8 +18,8 @@
+ 
+ package org.picketlink.identity.federation.core.sts.registry;
+ 
+-import javax.persistence.EntityManager;
+-import javax.persistence.EntityTransaction;
++import jakarta.persistence.EntityManager;
++import jakarta.persistence.EntityTransaction;
+ import java.io.IOException;
+ 
+ /**
+diff -uNr picketlink-orig/org/picketlink/identity/federation/core/sts/registry/RevokedToken.java picketlink/org/picketlink/identity/federation/core/sts/registry/RevokedToken.java
+--- picketlink-orig/org/picketlink/identity/federation/core/sts/registry/RevokedToken.java	2015-02-23 17:06:38.000000000 +0100
++++ picketlink/org/picketlink/identity/federation/core/sts/registry/RevokedToken.java	2023-12-21 09:00:31.823478000 +0100
+@@ -17,9 +17,9 @@
+  */
+ package org.picketlink.identity.federation.core.sts.registry;
+ 
+-import javax.persistence.Column;
+-import javax.persistence.Entity;
+-import javax.persistence.Id;
++import jakarta.persistence.Column;
++import jakarta.persistence.Entity;
++import jakarta.persistence.Id;
+ 
+ /**
+  * <p>
+diff -uNr picketlink-orig/org/picketlink/identity/federation/core/sts/registry/SecurityToken.java picketlink/org/picketlink/identity/federation/core/sts/registry/SecurityToken.java
+--- picketlink-orig/org/picketlink/identity/federation/core/sts/registry/SecurityToken.java	2015-02-23 17:06:38.000000000 +0100
++++ picketlink/org/picketlink/identity/federation/core/sts/registry/SecurityToken.java	2023-12-21 09:00:31.823478000 +0100
+@@ -17,10 +17,10 @@
+  */
+ package org.picketlink.identity.federation.core.sts.registry;
+ 
+-import javax.persistence.Column;
+-import javax.persistence.Entity;
+-import javax.persistence.Id;
+-import javax.persistence.Lob;
++import jakarta.persistence.Column;
++import jakarta.persistence.Entity;
++import jakarta.persistence.Id;
++import jakarta.persistence.Lob;
+ import java.io.ByteArrayInputStream;
+ import java.io.ByteArrayOutputStream;
+ import java.io.ObjectInputStream;


### PR DESCRIPTION
This change will patch Picketlink sources to make it compatible with Hibernate 6.4

( Resolves Meeds-io/MIPs#57 )