### PR TITLE
fix: SAML Logout not working - EXO-60293

### DIFF
--- a/agent/src/main/java/org/gatein/sso/agent/saml/PortalSAML2LogOutHandler.java
+++ b/agent/src/main/java/org/gatein/sso/agent/saml/PortalSAML2LogOutHandler.java
@@ -66,6 +66,8 @@ public class PortalSAML2LogOutHandler extends SAML2LogOutHandler
 
   private static final String OAUTH_COOKIE_NAME = "oauth_rememberme";
 
+  private static final String JSESSIONIDSSO_COOKIE_NAME = "JSESSIONIDSSO";
+
   private final SPLogOutHandler sp = new SPLogOutHandler();
 
   private static Log          log               = ExoLogger.getLogger(PortalSAML2LogOutHandler.class);
@@ -146,7 +148,9 @@ public class PortalSAML2LogOutHandler extends SAML2LogOutHandler
 
       try
       {
-         ServletContainerFactory.getServletContainer().logout(request, response);
+        if (request.getRemoteUser()!=null) {
+          ServletContainerFactory.getServletContainer().logout(request, response);
+        }
       }
       catch (Exception e)
       {
@@ -155,9 +159,15 @@ public class PortalSAML2LogOutHandler extends SAML2LogOutHandler
 
       // Remove rememberme cookie
       Cookie cookie = new Cookie(COOKIE_NAME, "");
-      cookie.setPath(request.getContextPath());
+      cookie.setPath("/");
       cookie.setMaxAge(0);
       response.addCookie(cookie);
+
+     // Remove JSESSIONIDSSO cookie
+     Cookie jsessionIdSSOCookie = new Cookie(JSESSIONIDSSO_COOKIE_NAME, "");
+     jsessionIdSSOCookie.setPath("/");
+     jsessionIdSSOCookie.setMaxAge(0);
+     response.addCookie(jsessionIdSSOCookie);
   
       // Remove oauth cookie
       Cookie oauthCookie = new Cookie(OAUTH_COOKIE_NAME, "");


### PR DESCRIPTION
Before this fix, when login out from saml, the request /portal/doling?GLO=true try to flush 3 cookies (JSESSIONID, rememberme, and oauth_rememberme), do setCookie with empty value. This not flush cookie in browser because cookies path is '/' and not '/portal' In addition, there is one more cookie to flush, which currently recreate the user session.

This commit use the correct path for the cookies and add the JSESSIONIDSSO cookie which should be flushed.

Resolves meeds-io/meeds-1771

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
