### PR TITLE
feat: Move deprecated dependency to optional artifact - Meeds-io/meeds#2537

### DIFF
--- a/sso-saml-plugin/pom.xml
+++ b/sso-saml-plugin/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <org.picketlink.federation.version>2.5.5.Final</org.picketlink.federation.version>
     <org.picketbox.version>4.0.20.Final</org.picketbox.version>
+    <javax.transaction.version>1.3</javax.transaction.version>
     <org.apache.santuario.version>1.5.1</org.apache.santuario.version>
     <org.jboss.security.jbossxacml.version>2.0.8.Final</org.jboss.security.jbossxacml.version>
     <org.jboss.security.jbosssx.version>2.0.4</org.jboss.security.jbosssx.version>
@@ -154,6 +155,12 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <!-- TODO: Artifacts to move to Jakarta EE -->
+      <dependency>
+        <groupId>javax.transaction</groupId>
+        <artifactId>javax.transaction-api</artifactId>
+        <version>${javax.transaction.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -213,6 +220,10 @@
     <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
     </dependency>
     <!-- JBoss Specs -->
     <dependency>


### PR DESCRIPTION
This change will move the usage of deprecated `javax.transaction` Artifact to be deployed only when sso-plugin artifact is added to server which is not used by default in Meeds.

Resolves https://github.com/Meeds-io/meeds/issues/2537