### PR TITLE
feat: Retrieve Inherited Memberships in SAML Roles - MEED-10149 - Meeds-io/MIPs#240

### DIFF
--- a/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/AbstractSPFormAuthenticator.java
+++ b/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/valve/AbstractSPFormAuthenticator.java
@@ -812,14 +812,13 @@ public abstract class AbstractSPFormAuthenticator extends BaseFormAuthenticator 
    * @return
    */
   private List<String> extractGateinRoles(String userId) {
-    OrganizationService organizationService =
-                                            PortalContainer.getInstance().getComponentInstanceOfType(OrganizationService.class);
+    OrganizationService organizationService = PortalContainer.getInstance().getComponentInstanceOfType(OrganizationService.class);
     RolesExtractor rolesExtractor = PortalContainer.getInstance().getComponentInstanceOfType(RolesExtractor.class);
     List<String> result = new ArrayList<>();
     Set<MembershipEntry> entries = new MembershipHashSet();
     Collection<Membership> memberships;
     try {
-      memberships = organizationService.getMembershipHandler().findMembershipsByUser(userId);
+      memberships = organizationService.getMembershipHandler().findMembershipsByUser(userId, true);
     } catch (Exception e) {
       memberships = null;
     }


### PR DESCRIPTION
This change will allow to retrieve inherited memberships of current user in the built User ACL Identity in SAML login flow.