### PR TITLE
fix : Make OIDC logout working when end_session_endpoint is present in configuration - MEED-10192 - meeds-io/meeds#4024

### DIFF
--- a/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
+++ b/sso-saml-plugin/src/main/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilter.java
@@ -102,7 +102,7 @@ public class SAML2LogoutFilter extends SPFilter implements SSOInterceptor {
         };
         // Step 1 : End - logout from the IDP (redirect to IDP logout URL)
         super.doFilter(requestWrapper, servletResponse, new EmptyFilterChain());
-        request.getSession().setAttribute(SAML_LOGOUT_ATTRIBUTE, request.getRequestURI() + "?" + request.getQueryString());
+        request.getSession().setAttribute(SAML_LOGOUT_ATTRIBUTE, request.getRequestURI());
       } else {
         // Step 3 : Call UIPortal.LogoutActionListener
         filterChain.doFilter(servletRequest, servletResponse);
@@ -130,7 +130,7 @@ public class SAML2LogoutFilter extends SPFilter implements SSOInterceptor {
   }
 
   public static boolean isPortalLogoutInProgress(HttpServletRequest request) {
-    return request.getQueryString() != null && request.getQueryString().contains("portal:action=Logout") && request.getRemoteUser() != null;
+    return request.getRequestURI().equals("/portal/logout") && request.getRemoteUser() != null;
   }
 
   public static boolean isSAMLLogoutInProgress(HttpServletRequest request) {

--- a/sso-saml-plugin/src/test/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilterTest.java
+++ b/sso-saml-plugin/src/test/java/org/gatein/sso/saml/plugin/filter/SAML2LogoutFilterTest.java
@@ -52,9 +52,7 @@ public class SAML2LogoutFilterTest extends TestCase {
     SAML2LogoutFilter saml2LogoutFilter = mock(SAML2LogoutFilter.class);
 
     // When
-    when(request.getRequestURI()).thenReturn("/portal");
-    when(request.getQueryString()).thenReturn("portal:action=Logout");
-    when(request.getParameter("portal:action")).thenReturn("Logout");
+    when(request.getRequestURI()).thenReturn("/portal/logout");
     when(request.getRemoteUser()).thenReturn("root");
     when(request.getSession()).thenReturn(httpSession);
     when(filterConfig.getServletContext()).thenReturn(servletContext);
@@ -75,7 +73,7 @@ public class SAML2LogoutFilterTest extends TestCase {
     saml2LogoutFilter.doFilter(request, response, chain);
 
     verify(httpSession, VerificationModeFactory.times(1)).setAttribute(eq(SAML2LogoutFilter.SAML_LOGOUT_ATTRIBUTE),
-                                                                       eq("/portal?portal:action=Logout"));
+                                                                       eq("/portal/logout"));
   }
 
   public void testLogoutProcessStep2() throws Exception {
@@ -128,10 +126,8 @@ public class SAML2LogoutFilterTest extends TestCase {
     SAML2LogoutFilter saml2LogoutFilter = mock(SAML2LogoutFilter.class);
 
     // When
-    when(request.getRequestURI()).thenReturn("/portal");
-    when(request.getQueryString()).thenReturn("portal:action=Logout");
-    when(request.getParameter("portal:action")).thenReturn("Logout");
-    when(httpSession.getAttribute(SAML2LogoutFilter.SAML_LOGOUT_ATTRIBUTE)).thenReturn("/portal?portal:action=Logout");
+    when(request.getRequestURI()).thenReturn("/portal/logout");
+    when(httpSession.getAttribute(SAML2LogoutFilter.SAML_LOGOUT_ATTRIBUTE)).thenReturn("/portal/logout");
     when(request.getRemoteUser()).thenReturn("root");
     when(request.getSession()).thenReturn(httpSession);
     when(filterConfig.getServletContext()).thenReturn(servletContext);


### PR DESCRIPTION
Before this fix, when using OIDC, some IDP provide a endsession_endpoint url, to make a logout on the IDP after being loggued out from the SP, and eXo do not use this url This commit ensure to send the user in this url if existing and if property exo.oauth.openid.propagate.logout is set to true To achieve this modification, this commit create a new handler in the platform to manage the logout : LogoutHandler on /portal/logout. The old logout code (UIPortal.LogoutActionListener) is removed

Resolves meeds-io/meeds#4024

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
